### PR TITLE
The project as a click-able link

### DIFF
--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -48,7 +48,7 @@
     
     <dl id="search-results">
       <% @results.each do |e| %>
-        <dt class="<%= e.event_type %>"><%= content_tag('span', h(e.project), :class => 'project') unless @project == e.project  %> 
+        <dt class="<%= e.event_type %>"><%= content_tag('span', link_to(e.project.name, project_path(e.project)), :class => 'project') unless @project == e.project  %> 
 <% if e.event_type == "attachment" then %>
 <strong>
 <%=	link_to highlight_tokens(truncate(e.event_title, :length => 255), @tokens), e.event_url	%>


### PR DESCRIPTION
If I click on a file among searched results the file is offered to be downloaded. There is no easy way how to get to the project to which the file belongs to. There is the project name only. In case of lots of projects in Redmine it means to use searching engine again to find the project.
If we simply substitute the project name with the project link we will be able to open the project easily.
The original view remains almost without any change, the project name is replaced with project link only.