### PR TITLE
fix bundle install failure

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,4 +19,6 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+source 'https://rubygems.org'
+
 gem 'activerecord-tablefree'


### PR DESCRIPTION
When running `bundle install`, I got:
```
Your Gemfile has no gem server sources. If you need gems that are not already on your machine, add a line like this to your Gemfile:
source 'https://rubygems.org'
Could not find concurrent-ruby-1.1.5 in any of the sources
```
And the issue is solved by this PR.