### PR TITLE
 "<repo_name> encountered an error and will be skipped: undefined method `split' for nil:NilClass"

### DIFF
--- a/extra/xapian_indexer.rb
+++ b/extra/xapian_indexer.rb
@@ -101,19 +101,19 @@ MIME_TYPES = {
 
 
 FORMAT_HANDLERS = {
-  pdf: $pdftotext,
-  doc: $catdoc,
-  xls: $xls2csv,
-  ppt: $catppt,
-  pps: $catppt,
-  docx: $unzip,
-  xlsx: $unzip,
-  pptx: $unzip,
-  ppsx: $unzip,
-  ods: $unzip,
-  odt: $unzip,
-  odp: $unzip,
-  rtf: $unrtf
+  'pdf' => $pdftotext,
+  'doc' => $catdoc,
+  'xls' => $xls2csv,
+  'ppt' => $catppt,
+  'pps' => $catppt,
+  'docx' => $unzip,
+  'xlsx' => $unzip,
+  'pptx' => $unzip,
+  'ppsx' => $unzip,
+  'ods' => $unzip,
+  'odt' => $unzip,
+  'odp' => $unzip,
+  'rtf' => $unrtf
 }.freeze
 
 VERSION = '0.2'
@@ -332,10 +332,10 @@ end
 
 def convert_to_text(fpath, type)
   text = nil
-  return text unless File.exist?(FORMAT_HANDLERS[type.to_sym].split(' ').first)
+  return text unless File.exist?(FORMAT_HANDLERS[type].split(' ').first)
   case type
     when 'pdf'    
-      text = "#{FORMAT_HANDLERS[type.to_sym]} #{fpath} -"
+      text = "#{FORMAT_HANDLERS[type]} #{fpath} -"
     when /(xlsx|docx|odt|pptx)/i
       system "#{$unzip} -d #{$tempdir}/temp #{fpath} > /dev/null", out: '/dev/null'
       case type
@@ -355,7 +355,7 @@ def convert_to_text(fpath, type)
         my_log "Error: #{e.to_s} reading #{fout}", true
       end
     else
-      text = "#{FORMAT_HANDLERS[type.to_sym]} #{fpath}"
+      text = "#{FORMAT_HANDLERS[type]} #{fpath}"
   end
   text
 end

--- a/extra/xapian_indexer.rb
+++ b/extra/xapian_indexer.rb
@@ -332,10 +332,10 @@ end
 
 def convert_to_text(fpath, type)
   text = nil
-  return text unless File.exist?(FORMAT_HANDLERS[type].split(' ').first)
+  return text unless File.exist?(FORMAT_HANDLERS[type.to_sym].split(' ').first)
   case type
     when 'pdf'    
-      text = "#{FORMAT_HANDLERS[type]} #{fpath} -"
+      text = "#{FORMAT_HANDLERS[type.to_sym]} #{fpath} -"
     when /(xlsx|docx|odt|pptx)/i
       system "#{$unzip} -d #{$tempdir}/temp #{fpath} > /dev/null", out: '/dev/null'
       case type
@@ -355,7 +355,7 @@ def convert_to_text(fpath, type)
         my_log "Error: #{e.to_s} reading #{fout}", true
       end
     else
-      text = "#{FORMAT_HANDLERS[type]} #{fpath}"
+      text = "#{FORMAT_HANDLERS[type.to_sym]} #{fpath}"
   end
   text
 end


### PR DESCRIPTION
When it comes to:
https://github.com/xelkano/redmine_xapian/blob/fedf924a377dbb89b866f645428ee9aafe9207eb/extra/xapian_indexer.rb#L335

it will throw an error ``` "<repo_name> encountered an error and will be skipped: undefined method `split' for nil:NilClass"```

According to https://stackoverflow.com/questions/40172567/how-to-create-hash-with-string-keys-by-default, the keys of `FORMAT_HANDLERS` is originally `Symbol`, this PR makes its keys `String` to resolve the error above. 