### PR TITLE
extra/xapian_indexer.rb -x: remove log for zoomby repos

### DIFF
--- a/extra/xapian_indexer.rb
+++ b/extra/xapian_indexer.rb
@@ -226,7 +226,7 @@ end
 
 def delete_log_by_repo_id(repo_id)
   Indexinglog.where(repository_id: repo_id).delete_all
-  my_log "Log for zoomby repo #{repo_id} removed!"
+  my_log "Log for zombied repo #{repo_id} removed!"
 end
 
 def walk(databasepath, indexconf, project, repository, identifier, entries)  
@@ -514,9 +514,9 @@ unless $onlyfiles
   end
   if $resetlog
     existing_repo_ids = Repository.all.to_a.map(&:id)
-    zoomby_repo_ids = Indexinglog.where.not(:repository_id => existing_repo_ids).to_a.map(&:repository_id).uniq
-    zoomby_repo_ids.each do |zoomby_repo_id|
-      delete_log_by_repo_id(zoomby_repo_id)
+    zombied_repo_ids = Indexinglog.where.not(:repository_id => existing_repo_ids).to_a.map(&:repository_id).uniq
+    zombied_repo_ids.each do |zombied_repo_id|
+      delete_log_by_repo_id(zombied_repo_id)
     end
   end
 end

--- a/extra/xapian_indexer.rb
+++ b/extra/xapian_indexer.rb
@@ -224,6 +224,11 @@ def delete_log(repository)
   my_log "Log for repo #{repo_name(repository)} removed!"
 end
 
+def delete_log_by_repo_id(repo_id)
+  Indexinglog.where(repository_id: repo_id).delete_all
+  my_log "Log for zoomby repo #{repo_id} removed!"
+end
+
 def walk(databasepath, indexconf, project, repository, identifier, entries)  
   return if entries.nil? || entries.size < 1
   my_log "Walk entries size: #{entries.size}"
@@ -505,6 +510,13 @@ unless $onlyfiles
       end
     else
       my_log "Project identifier #{identifier} not found or repository module not enabled, ignoring..."
+    end
+  end
+  if $resetlog
+    existing_repo_ids = Repository.all.to_a.map(&:id)
+    zoomby_repo_ids = Indexinglog.where.not(:repository_id => existing_repo_ids).to_a.map(&:repository_id).uniq
+    zoomby_repo_ids.each do |zoomby_repo_id|
+      delete_log_by_repo_id(zoomby_repo_id)
     end
   end
 end


### PR DESCRIPTION
Consider the following procedure:
1. Create repo A
2. Index repo A
3. Delete repo A
4. run extra/xapian_indexer.rb -x

In the last step, the log for repo A will not be deleted because it is not related to any projects hence cannot be found. This PR fixes it.