### PR TITLE
Fix for chinese-title-file

### DIFF
--- a/app/models/repofile.rb
+++ b/app/models/repofile.rb
@@ -46,7 +46,7 @@ class Repofile < ActiveRecord::Base
   attr_accessor :revision
 
   def event_title    
-    filename
+    filename.force_encoding 'UTF-8'
   end
 
   def event_datetime    
@@ -54,7 +54,8 @@ class Repofile < ActiveRecord::Base
   end
 
   def event_url
-    File.join Redmine::Utils::relative_url_root, url
+    #url = File.join Redmine::Utils::relative_url_root, url
+    url.force_encoding 'UTF-8'
   end
 
   def event_description


### PR DESCRIPTION
1. change title to utf8 encoding solves:
```
ActionView::Template::Error (incompatible character encodings: ASCII-8BIT and UTF-8):
    91:           <% end %>
    92:           <%= content_tag('span', h(e.format_identifier), class: 'identifier') if defined?(e.format_identifier) && !e.format_identifier.empty? %>
    93:           <% # end %>
    94:           <%= link_to(highlight_tokens(e.event_title.truncate(255), @tokens), e.event_url) %>
    95:         </dt>
    96:         <dd><span class="description"><%= highlight_tokens(e.event_description, @tokens) %></span>
    97:         <span class="author"><%= format_time(e.event_datetime) %></span></dd>
  
plugins/redmine_xapian/app/views/search/index.html.erb:94:in `block in _dec9f35c6d83bf3080fd2d9ef7734b5b'
plugins/redmine_xapian/app/views/search/index.html.erb:82:in `each'
plugins/redmine_xapian/app/views/search/index.html.erb:82:in `_dec9f35c6d83bf3080fd2d9ef7734b5b'
lib/redmine/sudo_mode.rb:65:in `sudo_mode'
```
2. In my case, my `url` is already prepended with `File.join Redmine::Utils::relative_url_root`, so `url = File.join Redmine::Utils::relative_url_root, url` is redundant(don't know if it's such case for other people)
  My `config/environment.rb`:
    ```ruby
    ActionController::Base.relative_url_root = RedmineApp::Application.routes.default_scope
    Redmine::Utils::relative_url_root = RedmineApp::Application.routes.default_scope
      
    ENV['RAILS_RELATIVE_URL_ROOT'] = "/redmine"
    Redmine::Utils::relative_url_root = ENV['RAILS_RELATIVE_URL_ROOT']
    ```
    My `config.ru`:
    ```ruby
    map ENV['RAILS_RELATIVE_URL_ROOT'] || '/' do
      run Rails.application
    end
    ```
    My `config/additional_environment.rb`:
    ```ruby
    config.relative_url_root = '/redmine'
    ```


3. change url to utf8 encoding solves `Wrong format of the URL` for chinese title file