### PR TITLE
[fix] NameError: uninitialized constant RedmineXapian::XapianSearch::Xapian

### DIFF
--- a/lib/redmine_xapian/xapian_search.rb
+++ b/lib/redmine_xapian/xapian_search.rb
@@ -20,6 +20,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 require 'uri'
+require 'xapian'
 
 # Redmine Xapian module
 module RedmineXapian


### PR DESCRIPTION
```
Can't open Xapian database /xxx/redmine/file_index/repodb- #<NameError: uninitialized constant RedmineXapian::XapianSearch::Xapian
database = Xapian::Database.new(databasepath)
```