### PR TITLE
docx JSON parse error

### DIFF
--- a/app/models/repofile.rb
+++ b/app/models/repofile.rb
@@ -83,7 +83,7 @@ class Repofile
       value = Redmine::Search.cache_store.fetch key
       next unless value
 
-      attributes = JSON.parse(value.gsub(/:([a-zA-z]+)/, '"\\1"').gsub('=>', ': ')).symbolize_keys
+      attributes = JSON.parse(value.gsub(/:([a-zA-z]+)=>/, '"\\1":')).symbolize_keys
       repofile = Repofile.new
       repofile.id = id
       repofile.filename = attributes[:filename]


### PR DESCRIPTION
For a docx file, the `value` in `attributes = JSON.parse(value.gsub(/:([a-zA-z]+)/, '"\\1"').gsub('=>', ': ')).symbolize_keys` is(only the part causing error kept):
```
"{:description=>\"<?xml version=\\\"1.0\\\" encoding=\\\"UTF-8\\\" standalone=\\\"yes\\\"?> <w:document xmlns:wpc=\\\"http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas\\\" xmlns:mc=\\\"http://schemas.openxmlformats.org/markup-compatibility/2006\\\" xmlns:o=\\\"urn:schemas-microsoft-com:office:office\\\" xmlns:r=\\\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\\\"\"}"
```
And `value.gsub(/:([a-zA-z]+)/, '"\\1"')` is:
```
{"description": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?> <w"document" xmlns"wpc"=\"http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas\" xmlns"mc"=\"http://schemas.openxmlformats.org/markup-compatibility/2006\" xmlns"o"=\"urn"schemas"-microsoft-com"office""office\"" xmlns"r"=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\""}
```
It can be seen that `w:document` is replaced with `w"document"`, this PR fixes https://github.com/xelkano/redmine_xapian/issues/141 partially.