### PR TITLE
Fix incorrect permission symbol for 'Version' container type

### DIFF
--- a/lib/redmine_xapian/container_type_helper.rb
+++ b/lib/redmine_xapian/container_type_helper.rb
@@ -26,7 +26,7 @@ module RedmineXapian
       def to_permission(container_type)
         case container_type
         when 'Version'
-          :view_files
+          :view_versions
         when 'Project'
           :view_project
         else


### PR DESCRIPTION
## Summary

The `to_permission` method in `ContainerTypeHelper` was returning `:view_files` for the 'Version' container type, but should return `:view_versions` to match Redmine's permission naming convention for viewing versions.

## Changes

- Changed the return value for 'Version' container type from `:view_files` to `:view_versions`

## Testing

This change ensures that permission checks for Version containers use the correct Redmine permission symbol `:view_versions` instead of the incorrect `:view_files`.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.